### PR TITLE
Fix numpy `np.float_` error

### DIFF
--- a/geosoft/gxpy/utility.py
+++ b/geosoft/gxpy/utility.py
@@ -32,6 +32,9 @@ import geosoft.gxapi as gxapi
 
 __version__ = geosoft.__version__
 
+# Override np.float_ with np.float64
+if tuple(map(int, np.__version__.split('.')[:2])) >= (1, 24):
+    np.float_ = np.float64
 
 def _t(s):
     return geosoft.gxpy.system.translate(s)

--- a/geosoft/gxpy/utility.py
+++ b/geosoft/gxpy/utility.py
@@ -32,6 +32,7 @@ import geosoft.gxapi as gxapi
 
 __version__ = geosoft.__version__
 
+
 def _t(s):
     return geosoft.gxpy.system.translate(s)
 

--- a/geosoft/gxpy/utility.py
+++ b/geosoft/gxpy/utility.py
@@ -32,13 +32,13 @@ import geosoft.gxapi as gxapi
 
 __version__ = geosoft.__version__
 
-# Override np.float_ with np.float64
-if tuple(map(int, np.__version__.split('.')[:2])) >= (1, 24):
-    np.float_ = np.float64
-
 def _t(s):
     return geosoft.gxpy.system.translate(s)
 
+
+# Override np.float_ with np.float64 if numpy version >= 2.0
+if tuple(map(int, np.__version__.split('.')[:2])) >= (2, 0):
+    np.float_ = np.float64
 
 # cached lookup tables
 _dummy_map = {}


### PR DESCRIPTION
For developers with a relatively recent version of numpy installed, they may see this error when using gxpy:

> `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.

In this PR I've added an override to fix this issue.

The other way to fix it would be to lift the minimum version of numpy for gxpy, but they may surface other things that need changing.